### PR TITLE
Add redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -28,8 +28,8 @@
     "pattern": "go.redirectingat.com(.*)?url=(?<baseUrl>.*)"
   },
   {
-    "name": "adidas-canada",
-    "pattern": "adidas-canada.sjv.io(.*)?u=(?<baseUrl>.*)"
+    "name": "sjv.io",
+    "pattern": ".*sjv\\.io.*\\?u=(?<baseUrl>.*)"
   },
   {
     "name": "canadiantire",

--- a/redirects.json
+++ b/redirects.json
@@ -114,5 +114,9 @@
 	{
 	  "name": "c2ukkg.net",
 	  "pattern": ".*c2ukkg\\.net.*\\?u=(?<baseUrl>.*)"
+	},
+	{
+	  "name": "dodxnr.net",
+	  "pattern": ".*dodxnr\\.net.*\\?u=(?<baseUrl>.*)"
 	}
 ]

--- a/redirects.json
+++ b/redirects.json
@@ -106,5 +106,13 @@
   {
     "name": "mkr3.net",
     "pattern": ".*mkr3\\.net.*\\?u=(?<baseUrl>.*)"
-  }
+  },
+	{
+	  "name": "fintelconnect.com",
+	  "pattern": ".*fintelconnect\\.com.*\\?u=(?<baseUrl>.*)"
+	},
+	{
+	  "name": "c2ukkg.net",
+	  "pattern": ".*c2ukkg\\.net.*\\?u=(?<baseUrl>.*)"
+	}
 ]

--- a/redirects.json
+++ b/redirects.json
@@ -5,7 +5,7 @@
   },
   {
     "name": "Best Buy",
-    "pattern": "bestbuyca.(.*).net(.*)\\?u=(?<baseUrl>.*)"
+    "pattern": "bestbuyca.(.*).net(.*)\\?u=(?<baseUrl>.*)\\?.*"
   },
   {
     "name": "HP",

--- a/redirects.json
+++ b/redirects.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Amazon",
-    "pattern": "www.amazon.ca/gp/redirect.html\\?ie=UTF8&location=(?<baseUrl>.*?)(&|ref%3D|%3F)"
+    "pattern": ".*amazon\\.(?:ca|com)\/gp\/redirect\\.html\\?ie=UTF8&location=(?<baseUrl>.*?)(?:&|ref%3D|%3F)"
   },
   {
     "name": "Best Buy",

--- a/redirects.json
+++ b/redirects.json
@@ -78,5 +78,33 @@
   {
     "name": "staples",
     "pattern": ".*staplescanada\\.4u8mqw\\.net.+\\?u=(?<baseUrl>.*)"
+  },
+  {
+    "name": "pjtra.com",
+    "pattern": ".*pjtra\\.com.*\\?url=(?<baseUrl>.*)&sid.*"
+  },
+  {
+    "name": "pjatr.com",
+    "pattern": ".*pjatr\\.com.*\\?url=(?<baseUrl>.*)&sid.*"
+  },
+  {
+    "name": "pntra.com",
+    "pattern": ".*pntra\\.com.*\\?url=(?<baseUrl>.*)&sid.*"
+  },
+  {
+    "name": "pntrs.com",
+    "pattern": ".*pntrs\\.com.*\\?url=(?<baseUrl>.*)&sid.*"
+  },
+  {
+    "name": "pntrac.com",
+    "pattern": ".*pntrac\\.com.*\\?url=(?<baseUrl>.*)&sid.*"
+  },
+  {
+    "name": "shareasale.com",
+    "pattern": ".*shareasale\\.com.*&urllink=(?<baseUrl>.*)"
+  },
+  {
+    "name": "mkr3.net",
+    "pattern": ".*mkr3\\.net.*\\?u=(?<baseUrl>.*)"
   }
 ]


### PR DESCRIPTION
Add 10 new redirects and tweaked a couple more.

Tweaks:
Amazon: include ".ca" and ".com"
Bestbuy: remove tracking parameters that are part of the URL
sjv.io: match all subdomains

New redirect examples:

pjtra.com
pntra.com
pntrs.com
pjatr.com
pntrac.com
These domains seem to be rotated through. Here are a few links which I've seen them appear:
https://forums.redflagdeals.com/sporting-life-under-armor-surge-3-running-shoe-men-women-junior-kids-babies-39-98-less-2673463/
https://forums.redflagdeals.com/canon-ca-rbc-clients-75-statement-credit-500-spend-get-250-creditfortravel-money-500-spend-until-feb-29-2672925/
https://forums.redflagdeals.com/golf-town-golf-town-womens-2021-m4-6-pw-sw-iron-set-graphite-shafts-524-99-2666699/

shareasale.com
https://forums.redflagdeals.com/fastestvpn-fastestvpn-27-usd-lifetime-plan-15-multi-logins-2666156/

mkr3.net
https://forums.redflagdeals.com/eddie-bauer-stowaway-packable-sling-3-0-30-50-off-2671096/#p38643194

fintelconnect.com
https://forums.redflagdeals.com/tangerine-earnmore-new-client-promo-earn-up-400-20-cash-back-6-00-savings-rate-5-months-2636126/#p37970401

c2ukkg.net
https://forums.redflagdeals.com/simons-cloudmonster-sneakers-men-25-off-149-95-use-10-off-comes-down-139-95-2671888/#p38655962

dodxnr.net
https://forums.redflagdeals.com/gap-extra-50-off-sale-20-off-code-10-cash-back-2671539/#p38647526